### PR TITLE
fix(#37): rescale slice positions across sample rates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,54 +1,92 @@
-# CLAUDE.md — Project Instructions
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+Making Waves — a browser-based WAV slicer for sample prep (Digitakt 2, etc).
+Runs entirely client-side, no server processing. Works on desktop and iOS Safari.
+
+## Commands
+- `npx vite` — dev server
+- `npx tsc --noEmit` — type-check (run after every change)
+- `npx vite build` — production build (runs tsc first, output in `dist/`)
 
 ## Working Style
 - Do ONE thing at a time. Don't bundle multiple features into a single change.
 - Explain what you're doing as you do it, so the user learns about web development.
 - After each change, type-check with `npx tsc --noEmit` before moving on.
-- Keep modules small and focused. When a function or concern grows, extract it into its own module rather than letting files become monolithic.
+- Keep modules small and focused. Extract new concerns into their own modules.
 - Don't grow spaghetti — refactor proactively when things get tangled.
 
+## Git Commits
+- ALWAYS write commit message to `/tmp/commit-msg.txt`, then `git commit -F /tmp/commit-msg.txt`.
+- NEVER use `git commit -m` — special chars break it.
+
 ## Tech Stack
-- Vite + TypeScript (strict mode, ESNext target)
+- Vite + TypeScript (strict mode, ESNext target, `noUnusedLocals`/`noUnusedParameters`)
 - Vanilla DOM — no frameworks
 - Web Audio API (AudioContext, AudioBufferSourceNode, AnalyserNode)
 - Canvas 2D for waveform rendering
 - Pointer events for unified touch + mouse
 - ES modules, no bundler plugins
+- No runtime dependencies (devDependencies only: vite, typescript)
 
 ## Architecture
-- `src/audio.ts` — AudioContext singleton, WAV decoding
-- `src/waveform.ts` — Peak generation + Canvas 2D drawing
-- `src/slicer.ts` — Slice state (overlapping start/end pairs, like rainbow parens)
-- `src/player.ts` — Playback engine with AnalyserNode
-- `src/wav-writer.ts` — RIFF/WAV PCM encoder
-- `src/viewport.ts` — Zoom/pan state, gesture locking, dead-zone centering
-- `src/main.ts` — Glue: DOM events, app state, wires modules together
-- `src/style.css` — Dark theme, responsive
 
-## Slice Model
-Slices are independent [start, end] pairs that can overlap.
+### Core Audio Pipeline
+- `src/audio.ts` — AudioContext singleton, WAV decoding
+- `src/player.ts` — Playback engine with AnalyserNode + animated playhead
+- `src/wav-writer.ts` — RIFF/WAV PCM encoder (16-bit/24-bit)
+- `src/dsp.ts` — Pure DSP utilities (transient detection, zero-crossing analysis), Web Worker safe
+
+### Rendering & Viewport
+- `src/waveform.ts` — Peak generation + Canvas 2D drawing
+- `src/viewport.ts` — Zoom/pan state, gesture locking, dead-zone centering
+- `src/zoom.ts` — Zoom state cycling (out → segment → marker → out)
+- `src/coords.ts` — Coordinate-space types and conversion (sample ↔ pixel, viewport)
+- `src/constants.ts` — Shared constants (e.g. SELECT_ZONE ratio)
+
+### Slice Model & State
+- `src/slicer.ts` — Slice state (overlapping start/end pairs, rainbow-paren colors)
+- `src/undo.ts` — Undo/redo stack with full state snapshots
+- `src/slice-list.ts` — Sidebar slice list UI with pooled DOM rows
+
+### Input Handling
+- `src/keyboard.ts` — Keyboard shortcut handler, delegates to context callbacks
+- `src/touch.ts` — Multi-touch gestures (pan, pinch-zoom, hold-drag) for mobile
+
+### Persistence & I/O
+- `src/project.ts` — Project save/load via ZIP bundles and JSON sidecars (pure logic, no DOM)
+- `src/persistence.ts` — Session persistence (IndexedDB for WAV, localStorage for metadata)
+- `src/zip-writer.ts` — Minimal STORE-only ZIP encoder (no compression)
+- `src/zip-reader.ts` — Minimal STORE-only ZIP decoder
+
+### UI & Glue
+- `src/main.ts` — Glue: DOM events, app state, wires all modules together
+- `src/icons.ts` — Heroicon SVG strings for button icons
+- `src/debug.ts` — Runtime-toggleable debug logging
+- `src/style.css` — Dark theme, responsive layout
+
+## Key Domain Concepts
+
+### Slice Model
+Slices are independent [start, end] sample-frame pairs that can overlap.
 Colors match start/end markers like rainbow parentheses.
 Two-click creation: first click = start, second click = end.
 Slices are kept sorted by start position (then end). Indices may
-change after creation or marker drag — track by object reference.
+change after creation or marker drag — track by object reference, not index.
 
-## Viewport
+### Viewport Zones
 - Top 10% of canvas = selection zone (pointer cursor, heavier tint)
 - Bottom 90% = marker placement zone (crosshair cursor)
+- On mobile: bottom ~20% = cut zone (tap to place markers, scissors affordance)
 - Waveform draws between 10%–90% of canvas height
+
+### Viewport Behavior
 - Zoom: fall-off via sqrt, sticky anchor per gesture, Cinemachine dead-zone centering
 - Pan/zoom direction locks per gesture (first axis wins, 150ms reset)
 - `j`/`k` selection triggers Cinemachine-style viewport follow
 
 ## Key Files
-- `TASKS.md` — Feature checklist with milestones
+- `TASKS.md` — Feature checklist with milestones and issue numbers
 - `Requirements.md` — Full product requirements
-
-## Commands
-- `npx vite` — dev server
-- `npx tsc --noEmit` — type-check
-- `npx vite build` — production build
-
-## Git Commits
-- ALWAYS write commit message to a temp file, then `git commit -F /tmp/commit-msg.txt`.
-- Never use `-m` with inline strings — too easy to break on special chars.

--- a/src/audio.ts
+++ b/src/audio.ts
@@ -89,8 +89,11 @@ export async function decodeAudioFile(file: File): Promise<AudioBuffer> {
 /**
  * Decode a raw WAV ArrayBuffer into an AudioBuffer.
  * Used when restoring a session from IndexedDB (no File object needed).
+ *
+ * Uses getAudioContext() instead of ensureResumed() so it doesn't block
+ * on a user gesture — decodeAudioData works on a suspended context.
  */
 export async function decodeAudioData(arrayBuffer: ArrayBuffer): Promise<AudioBuffer> {
-  const ac = await ensureResumed();
+  const ac = getAudioContext();
   return ac.decodeAudioData(arrayBuffer);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -289,6 +289,8 @@ async function loadProject(file: File): Promise<void> {
   showLoading(`Loading project…`);
   try {
     const data = await loadProjectZip(file);
+    // Save raw WAV bytes to IDB so the session can be restored on next launch
+    data.originalFile.arrayBuffer().then(ab => saveBufferToIDB(ab)).catch(() => {/* quota */});
     openSession(data.audioBuffer, data.originalFile, data.projectName, data.slices);
     debug(`Project loaded: ${data.slices.length} slices restored`);
   } catch (err) {
@@ -1171,8 +1173,10 @@ window.addEventListener('pagehide', () => {
   const meta = loadMetaFromLS();
   if (!meta) return;
 
+  showLoading(`Restoring "${meta.projectName}"…`);
+
   const rawWav = await loadBufferFromIDB();
-  if (!rawWav) return;
+  if (!rawWav) { hideLoading(); return; }
 
   try {
     // Re-decode from the stored raw WAV bytes — never stores decoded PCM
@@ -1184,5 +1188,7 @@ window.addEventListener('pagehide', () => {
     // Corrupted data — clear and start fresh
     console.error('[making-waves] Session restore failed:', err);
     clearSession();
+  } finally {
+    hideLoading();
   }
 })();

--- a/src/project.ts
+++ b/src/project.ts
@@ -20,6 +20,29 @@ interface Sidecar {
   slices: { start: number; end: number; name?: string }[];
 }
 
+/**
+ * Rescale slice positions when the sidecar was saved at a different sample
+ * rate than the current AudioContext decoded the audio to.
+ *
+ * Web Audio's decodeAudioData resamples to the AudioContext's sample rate,
+ * which varies by device (e.g. 48 kHz on iOS, 44.1 kHz on a Mac with a
+ * 44.1 kHz audio interface). Slice positions stored as sample frames must
+ * be converted to the new rate or they drift — increasingly toward the end.
+ */
+function rescaleSlices(
+  slices: { start: number; end: number; name?: string }[],
+  fromRate: number,
+  toRate: number,
+): { start: number; end: number; name?: string }[] {
+  if (fromRate === toRate) return slices;
+  const ratio = toRate / fromRate;
+  return slices.map(s => ({
+    start: Math.round(s.start * ratio),
+    end: Math.round(s.end * ratio),
+    name: s.name,
+  }));
+}
+
 export interface ProjectData {
   audioBuffer: AudioBuffer;
   originalFile: File;
@@ -49,8 +72,9 @@ export async function loadProjectZip(file: File): Promise<ProjectData> {
 
   const audioBuffer = await decodeAudioFile(wavFile);
   const projectName = sidecar.projectName ?? sidecar.originalFile.replace(/\.wav$/i, '');
+  const slices = rescaleSlices(sidecar.slices, sidecar.sampleRate, audioBuffer.sampleRate);
 
-  return { audioBuffer, originalFile: wavFile, slices: sidecar.slices, projectName };
+  return { audioBuffer, originalFile: wavFile, slices, projectName };
 }
 
 /** Build a ZIP bundle: original WAV + sidecar JSON + per-slice WAVs. */
@@ -110,23 +134,26 @@ export async function loadSidecarJson(file: File, audioBuffer: AudioBuffer): Pro
   const text = await file.text();
   const data = JSON.parse(text) as Sidecar;
 
-  if (data.sampleRate !== audioBuffer.sampleRate) {
+  // Sample rate may differ if the sidecar was created on a device whose
+  // AudioContext ran at a different rate (e.g. 48 kHz iOS vs 44.1 kHz Mac).
+  // Rescale positions instead of rejecting the file.
+  const slices = rescaleSlices(data.slices, data.sampleRate, audioBuffer.sampleRate);
+
+  // Verify total length matches after accounting for resampling.
+  const expectedSamples = Math.round(data.totalSamples * audioBuffer.sampleRate / data.sampleRate);
+  if (Math.abs(expectedSamples - audioBuffer.length) > 1) {
     throw new Error(
-      `Sidecar sample rate (${data.sampleRate} Hz) does not match loaded audio (${audioBuffer.sampleRate} Hz).`
-    );
-  }
-  if (data.totalSamples !== audioBuffer.length) {
-    throw new Error(
-      `Sidecar length (${data.totalSamples} samples) does not match loaded audio (${audioBuffer.length} samples). ` +
+      `Sidecar length (${data.totalSamples} samples at ${data.sampleRate} Hz) does not match ` +
+      `loaded audio (${audioBuffer.length} samples at ${audioBuffer.sampleRate} Hz). ` +
       `Make sure you're loading the sidecar for "${data.originalFile}".`
     );
   }
 
   return {
     projectName: data.projectName ?? data.originalFile.replace(/\.wav$/i, ''),
-    sampleRate: data.sampleRate,
-    totalSamples: data.totalSamples,
-    slices: data.slices,
+    sampleRate: audioBuffer.sampleRate,
+    totalSamples: audioBuffer.length,
+    slices,
   };
 }
 


### PR DESCRIPTION
## Summary
- **Sample rate rescale**: Slice positions saved on iOS (48 kHz) drifted increasingly when opened on Mac (44.1 kHz). Now rescales positions by `toRate/fromRate` on both ZIP and sidecar load paths.
- **Session restore fix**: Restore no longer blocks on a user gesture (AudioContext suspension), shows a loading spinner, and now persists project ZIP sessions (was only persisting direct WAV uploads).
- **CLAUDE.md update**: Full module inventory covering all 20 source files.

Closes #37

## Test plan
- [x] Load TRACK01.zip on Mac (44.1 kHz speakers) — slices line up correctly
- [x] Session restore shows spinner and loads instantly without needing a click
- [x] Loading a project ZIP persists to IndexedDB and restores on next launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)